### PR TITLE
fix: Proper initialization of `bthome_measurement_record_t`

### DIFF
--- a/components/bthome_receiver_base/bthome_receiver_base_hub.cpp
+++ b/components/bthome_receiver_base/bthome_receiver_base_hub.cpp
@@ -127,7 +127,7 @@ namespace esphome
             case BTHOME_DIMMER_EVENT:
             {
               bthome_measurement_event_record_t event_data{measurement_type, (uint8_t)((int)value & 0xff), (uint8_t)((int)value << 8 & 0xff)};
-              bthome_measurement_record_t data{false, .d = {.event = event_data}};
+              bthome_measurement_record_t data{.is_value=false, .d = {.event = event_data}};
               measurements.push_back(data);
               break;
             }
@@ -136,7 +136,7 @@ namespace esphome
             default:
             {
               bthome_measurement_value_record_t value_data{measurement_type, value};
-              bthome_measurement_record_t data{true, .d = {.value = value_data}};
+              bthome_measurement_record_t data{.is_value = true, .d = {.value = value_data}};
               measurements.push_back(data);
             }
             break;


### PR DESCRIPTION
* Newer compilers are more strict about the initialization of structs, so we need to initialize the `is_value` field of `bthome_measurement_record_t` to avoid an error:

  ```
  src/esphome/components/bthome_receiver_base/bthome_receiver_base_hub.cpp:130:55: error: either all initializer clauses should be designated or none of them should be
  130 |               bthome_measurement_record_t data{false, .d = {.event = event_data}};
      |                                                       ^
  src/esphome/components/bthome_receiver_base/bthome_receiver_base_hub.cpp:139:54:
    error: either all initializer clauses should be designated or none of them should be
  139 |               bthome_measurement_record_t data{true, .d = {.value = value_data}};
  ```